### PR TITLE
Add retry logic for apt-get installs

### DIFF
--- a/jobs/godojo/templates/bin/pre-start.erb
+++ b/jobs/godojo/templates/bin/pre-start.erb
@@ -3,9 +3,72 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-DEBIAN_FRONTEND=noninteractive apt-get install -y libpq-dev python3.11
+DEBIAN_FRONTEND=noninteractive
 
-DEBIAN_FRONTEND=noninteractive apt-get remove -y libnode72
+set +e                                                                               # Need to turn this off so retry will be allowed
+
+COMMAND="apt-get install -y libpq-dev python3.11"                                    # Command to execute
+MAX_RETRIES=3                                                                        # Maximum number of retries
+DELAY=5                                                                              # Delay between retries in seconds
+ATTEMPT=0                                                                            # Initialize counter
+
+echo "Attempting to install libpq-dev python3.11..."
+# Execute the command with retries
+while [ $ATTEMPT -lt $MAX_RETRIES ]; do
+    ((ATTEMPT++))
+    echo "Attempt $ATTEMPT: Running '$COMMAND'..."
+    
+    # Run the command
+    $COMMAND
+    
+    # Check if the command succeeded
+    if [ $? -eq 0 ]; then
+        echo "Command succeeded on attempt $ATTEMPT."
+        break
+    else
+        echo "Command failed on attempt $ATTEMPT."
+        if [ $ATTEMPT -lt $MAX_RETRIES ]; then
+            echo "Retrying in $DELAY seconds..."
+            sleep $DELAY
+        else
+            echo "Command failed after $MAX_RETRIES attempts, terminating install..."
+            exit 1
+        fi
+    fi
+done
+
+
+COMMAND="apt-get remove -y libnode72"                                                # Command to execute
+MAX_RETRIES=3                                                                        # Maximum number of retries
+DELAY=5                                                                              # Delay between retries in seconds
+ATTEMPT=0                                                                            # Initialize counter
+
+echo "Attempting to remove libnode72..."
+# Execute the command with retries
+while [ $ATTEMPT -lt $MAX_RETRIES ]; do
+    ((ATTEMPT++))
+    echo "Attempt $ATTEMPT: Running '$COMMAND'..."
+    
+    # Run the command
+    $COMMAND
+    
+    # Check if the command succeeded
+    if [ $? -eq 0 ]; then
+        echo "Command succeeded on attempt $ATTEMPT."
+        break
+    else
+        echo "Command failed on attempt $ATTEMPT."
+        if [ $ATTEMPT -lt $MAX_RETRIES ]; then
+            echo "Retrying in $DELAY seconds..."
+            sleep $DELAY
+        else
+            echo "Command failed after $MAX_RETRIES attempts, terminating install..."
+            exit 1
+        fi
+    fi
+done
+
+set -e                                                     # Retry is complete, re-enable
 
 cd /var/vcap/jobs/godojo/bin
 PYPATH="/usr/bin/python3.11" /var/vcap/jobs/godojo/packages/godojo/godojo


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds retry logic to apt-get installs and deletes
- Should fix https://github.com/cloud-gov/private/issues/2334
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, adds retry logic to the existing pre-start scripting
