### PR TITLE
Support new stemcell for package install of libpq

### DIFF
--- a/jobs/godojo/templates/bin/pre-start.erb
+++ b/jobs/godojo/templates/bin/pre-start.erb
@@ -7,6 +7,36 @@ DEBIAN_FRONTEND=noninteractive
 
 set +e                                                                               # Need to turn this off so retry will be allowed
 
+COMMAND="apt-get update"                                                             # Command to execute
+MAX_RETRIES=3                                                                        # Maximum number of retries
+DELAY=5                                                                              # Delay between retries in seconds
+ATTEMPT=0                                                                            # Initialize counter
+
+echo "Attempting to install libpq-dev python3.11..."
+# Execute the command with retries
+while [ $ATTEMPT -lt $MAX_RETRIES ]; do
+    ((ATTEMPT++))
+    echo "Attempt $ATTEMPT: Running '$COMMAND'..."
+    
+    # Run the command
+    $COMMAND
+    
+    # Check if the command succeeded
+    if [ $? -eq 0 ]; then
+        echo "Command succeeded on attempt $ATTEMPT."
+        break
+    else
+        echo "Command failed on attempt $ATTEMPT."
+        if [ $ATTEMPT -lt $MAX_RETRIES ]; then
+            echo "Retrying in $DELAY seconds..."
+            sleep $DELAY
+        else
+            echo "Command failed after $MAX_RETRIES attempts, terminating install..."
+            exit 1
+        fi
+    fi
+done
+
 COMMAND="apt-get install -y libpq-dev python3.11"                                    # Command to execute
 MAX_RETRIES=3                                                                        # Maximum number of retries
 DELAY=5                                                                              # Delay between retries in seconds


### PR DESCRIPTION
## Changes proposed in this pull request:

- Pre-start script for godojo was failing with:

```
Attempting to install libpq-dev python3.11...
Attempt 1: Running 'apt-get install -y libpq-dev python3.11'...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libpq-dev
E: Unable to locate package python3.11
E: Couldn't find any package by glob 'python3.11'
E: Couldn't find any package by regex 'python3.11'
Command failed on attempt 1.
```
- This happened during a new stemcell rollout, manually running the apt-get update before manually running the pre-start script fixed the error during debugging, this makes the change more permanent
- Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixes an edge case of a new stemcell that didn't have its package manager updated before installing libpq, no changes to security boundaries or alliances in the all-valley tournament.
