### PR TITLE
adds scan_file_max_size setting

### DIFF
--- a/jobs/godojo/spec
+++ b/jobs/godojo/spec
@@ -63,6 +63,10 @@ properties:
     description: |
       The url that will be used by defectdojo to send email notifications
     default: "smtp://user@:password@localhost:25"
+  dojo.settings.scan_file_max_size:
+    description: |
+      The max file size for imported scans in MB
+    default: 100
   dojo.db.engine:
     description: |
       Database engine to use (SQLite, MySQL, PostgreSQL, MariaDB) Note: CASE sEnSiTiVE!

--- a/jobs/godojo/templates/config/dojo.env.erb
+++ b/jobs/godojo/templates/config/dojo.env.erb
@@ -18,5 +18,6 @@ export DD_SOCIAL_AUTH_OIDC_AUTHORIZATION_URL=<%= p('dojo.auth.oidc_authorization
 export DD_SOCIAL_AUTH_OIDC_USERINFO_URL=<%= p('dojo.auth.oidc_userinfo_url') %>
 export DD_SOCIAL_AUTH_OIDC_JWKS_URI=<%= p('dojo.auth.oidc_jwks_uri') %>
 export DD_EMAIL_URL=<%= p('dojo.settings.email_url') %>
+export DD_SCAN_FILE_MAX_SIZE=<%= p('dojo.settings.scan_file_max_size') %>
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a setting for changing the max file size of uploaded scans

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding a setting for adjusting the max file size of uploaded scans
