### PR TITLE
using separate processes and adding drain script

### DIFF
--- a/jobs/godojo/monit
+++ b/jobs/godojo/monit
@@ -9,3 +9,15 @@ check device os-ephemeral_disk with path /var/vcap/data
 
 check device os-persistent_disk with path /var/vcap/store
   if SPACE usage > 80% then alert
+
+check process celeryworker
+  with pidfile /var/vcap/sys/run/bpm/godojo/celeryworker.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start godojo -p celeryworker"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop godjo -p celeryworker"
+  group vcap
+
+check process celerybeat
+  with pidfile /var/vcap/sys/run/bpm/godojo/celerybeat.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start godojo -p celerybeat"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop godjo -p celerybeat"
+  group vcap

--- a/jobs/godojo/spec
+++ b/jobs/godojo/spec
@@ -3,7 +3,10 @@ name: godojo
 
 templates:
   bin/godojo: bin/godojo.sh
+  bin/celeryworker: bin/celeryworker.sh
+  bin/celerybeat: bin/celerybeat.sh
   bin/pre-start.erb: bin/pre-start
+  bin/drain.erb: bin/drain
   config/bpm.yml.erb: config/bpm.yml
   config/dojo.env.erb: config/dojo.env
   config/dojoConfig.yml.erb: bin/dojoConfig.yml

--- a/jobs/godojo/templates/bin/celerybeat
+++ b/jobs/godojo/templates/bin/celerybeat
@@ -9,9 +9,8 @@ cd /var/vcap/jobs/godojo/django-DefectDojo
 
 #use godojo env
 source /var/vcap/jobs/godojo/bin/activate
-source /var/vcap/jobs/godojo/config/dojo.env
 
 export PATH=/var/vcap/jobs/godojo/bin:${PATH}
 
-# Startup webserver using socket
-uwsgi --socket dojo.sock --wsgi-file wsgi.py --buffer-size 6144 -p 2 -T --threads 10
+# Startup the Celery beat process
+celery --app dojo beat -l info

--- a/jobs/godojo/templates/bin/celeryworker
+++ b/jobs/godojo/templates/bin/celeryworker
@@ -9,9 +9,8 @@ cd /var/vcap/jobs/godojo/django-DefectDojo
 
 #use godojo env
 source /var/vcap/jobs/godojo/bin/activate
-source /var/vcap/jobs/godojo/config/dojo.env
 
 export PATH=/var/vcap/jobs/godojo/bin:${PATH}
 
-# Startup webserver using socket
-uwsgi --socket dojo.sock --wsgi-file wsgi.py --buffer-size 6144 -p 2 -T --threads 10
+#start celery workers
+celery --app=dojo worker --loglevel "info" --pool "prefork" --concurrency "4"

--- a/jobs/godojo/templates/bin/drain.erb
+++ b/jobs/godojo/templates/bin/drain.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# check if the process is running
+pid_path=/var/vcap/sys/run/bpm/godojo/celerybeat.pid
+if [ ! -f "$pid_path" ]; then echo 0; exit 0; fi
+pid=$(<"$pid_path")
+if ! ps -p "$pid" >/dev/null; then echo 0; exit 0; fi
+
+kill -9 $pid
+
+# check if the process is running
+pid_path=/var/vcap/sys/run/bpm/godojo/celeryworker.pid
+if [ ! -f "$pid_path" ]; then echo 0; exit 0; fi
+pid=$(<"$pid_path")
+if ! ps -p "$pid" >/dev/null; then echo 0; exit 0; fi
+
+kill -9 $pid
+
+echo 0; exit 0

--- a/jobs/godojo/templates/config/bpm.yml.erb
+++ b/jobs/godojo/templates/config/bpm.yml.erb
@@ -27,3 +27,39 @@ processes:
       writable: true
     capabilities:
     - SYS_RESOURCE
+  - name: celeryworker
+    executable: /var/vcap/jobs/godojo/bin/celeryworker.sh
+    additional_volumes:
+    - path: /var/vcap/sys/tmp/godojo
+      writable: true
+      allow_executions: true
+    - path: /var/vcap/jobs/godojo
+      writeable: true
+    - path: /var/vcap/jobs/godojo/config
+      writable: true
+    - path: /var/vcap/jobs/godojo/django-DefectDojo
+      writable: true
+    - path: /var/vcap/jobs/godojo/bin
+      writeable: true
+      allow_executions: true
+    - path: /var/vcap/data/jobs/godojo
+      writeable: true
+      allow_executions: true
+  - name: celerybeat
+    executable: /var/vcap/jobs/godojo/bin/celerybeat.sh
+    additional_volumes:
+    - path: /var/vcap/sys/tmp/godojo
+      writable: true
+      allow_executions: true
+    - path: /var/vcap/jobs/godojo
+      writeable: true
+    - path: /var/vcap/jobs/godojo/config
+      writable: true
+    - path: /var/vcap/jobs/godojo/django-DefectDojo
+      writable: true
+    - path: /var/vcap/jobs/godojo/bin
+      writeable: true
+      allow_executions: true
+    - path: /var/vcap/data/jobs/godojo
+      writeable: true
+      allow_executions: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- This fixes an issue where the celery processes weren't starting up. Moving them to their own separate processes will also make them easier to maintain
- Adds a drain script to kill all the celery processes so the vm can be successfully restarted

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Makes sure that the defectdojo celery processes are running so that removing duplicates and other tasks managed by celery work properly
