### PR TITLE
decrease concurrency of celery workers

### DIFF
--- a/jobs/godojo/templates/bin/celeryworker
+++ b/jobs/godojo/templates/bin/celeryworker
@@ -13,4 +13,4 @@ source /var/vcap/jobs/godojo/bin/activate
 export PATH=/var/vcap/jobs/godojo/bin:${PATH}
 
 #start celery workers
-celery --app=dojo worker --loglevel "info" --pool "prefork" --concurrency "4"
+celery --app=dojo worker --loglevel "info" --pool "prefork" --concurrency "2"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Decreases concurrency to match the number of cpu cores as recommended by celery documentation

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, should fix memory usage issues
