### PR TITLE
update node version

### DIFF
--- a/jobs/godojo/templates/config/dojoConfig.yml.erb
+++ b/jobs/godojo/templates/config/dojoConfig.yml.erb
@@ -156,4 +156,4 @@ Settings:
 Options:
   YarnGPG: "https://dl.yarnpkg.com/debian/pubkey.gpg" # DD_
   YarnRepo: "deb https://dl.yarnpkg.com/debian/ stable main" # DD_
-  NodeURL: "https://deb.nodesource.com/setup_18.x" #
+  NodeURL: "https://deb.nodesource.com/setup_22.x" #


### PR DESCRIPTION
## Changes proposed in this pull request:

- DefectDojo requires a newer version of Node

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating node version
